### PR TITLE
Moving WriterOFF-specific color conversion

### DIFF
--- a/lib/happah/writers/Writer.h
+++ b/lib/happah/writers/Writer.h
@@ -58,13 +58,13 @@ Stream& operator<<(Stream& stream, const VertexPN<Space>& vertex) {
 
 template<class Stream, class Space>
 Stream& operator<<(Stream& stream, const VertexPC<Space>& vertex) {
-     stream << vertex.position << ' ' << hpucolor(vertex.color*255.0f);
+     stream << vertex.position << ' ' << vertex.color;
      return stream;
 }
 
 template<class Stream, class Space>
 Stream& operator<<(Stream& stream, const VertexPNC<Space>& vertex) {
-     stream << vertex.position << ' ' << vertex.normal << ' ' << hpucolor(vertex.color*255.0f);
+     stream << vertex.position << ' ' << vertex.normal << ' ' << vertex.color;
      return stream;
 }
 }//namespace happah

--- a/lib/happah/writers/WriterOFF.h
+++ b/lib/happah/writers/WriterOFF.h
@@ -80,5 +80,16 @@ Writer<OFF>& operator<<(Writer<OFF>& writer, const std::vector<T>& ts) {
      return writer;
 }
 
+template<class Space>
+Writer<OFF>& operator<<(Writer<OFF>& stream, const VertexPC<Space>& vertex) {
+     stream << vertex.position << ' ' << hpucolor(vertex.color*255.0f);
+     return stream;
+}
+
+template<class Space>
+Writer<OFF>& operator<<(Writer<OFF>& stream, const VertexPNC<Space>& vertex) {
+     stream << vertex.position << ' ' << vertex.normal << ' ' << hpucolor(vertex.color*255.0f);
+     return stream;
+}
 }//namespace happah
 


### PR DESCRIPTION
Vertex colors are internally stored as hpcolor [=`glm::vec4`]. The OFF encoding represents colors as decimal-encoded integers in the range 0..255 per color component, which can be represented by `hpucolor` [=`glm::uvec4`]. Added a specialization of `operator<<()` for `Writer<OFF>` that converts colors for proper output, while adjusting the generic output functions to send the vertex color component as-is to the output stream.