### PR TITLE
Automated checks and configuration of build deps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_LANG_PUSH([C++])
 AC_CHECK_HEADER([glm/glm.hpp], [], [AC_MSG_ERROR([Could not find glm/glm.hpp.])])
 AC_CHECK_HEADER([lpsolve/lp_lib.h], [], [AC_MSG_ERROR([Could not find lpsolve/lp_lib.h.])])
 AC_LANG_POP([C++])
-AX_BOOST_BASE
+AX_BOOST_BASE([1.62])
 AX_BOOST_IOSTREAMS
 PKG_CHECK_MODULES([eigen3], [eigen3])
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,15 @@ LT_INIT
 
 AC_PROG_CXX
 AM_PROG_LIBTOOL
+PKG_PROG_PKG_CONFIG
+# Instruct autoconf to use the c++ compiler for subsequent compile checks
+AC_LANG_PUSH([C++])
+AC_CHECK_HEADER([glm/glm.hpp], [], [AC_MSG_ERROR([Could not find glm/glm.hpp.])])
+AC_CHECK_HEADER([lpsolve/lp_lib.h], [], [AC_MSG_ERROR([Could not find lpsolve/lp_lib.h.])])
+AC_LANG_POP([C++])
+AX_BOOST_BASE
+AX_BOOST_IOSTREAMS
+PKG_CHECK_MODULES([eigen3], [eigen3])
 
 AC_CONFIG_FILES(Makefile lib/Makefile test/Makefile)
 AC_OUTPUT

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -94,5 +94,5 @@ nobase_include_HEADERS = \
 libhappah_la_CPPFLAGS = $(eigen3_CFLAGS) $(BOOST_CPPFLAGS)
 libhappah_la_CXXFLAGS = -std=c++1z -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable
 libhappah_la_LDFLAGS = -version-info 0:0:0 $(eigen3_LDFLAGS) $(BOOST_LDFLAGS)
-libhappah_la_LIBADD = -llpsolve55 $(eigen3_LIBS) $(BOOST_IOSTREAMS_LIB)
+libhappah_la_LIBADD = -llpsolve55 $(eigen3_LIBS) $(BOOST_IOSTREAMS_LIB) -lstdc++fs
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -91,6 +91,8 @@ nobase_include_HEADERS = \
      happah/weighers/HoleyWallsWeigher.hpp \
      happah/weighers/HoleyWallWeigher.hpp \
      happah/weighers/TraversableEdgeLengthWeigher.hpp
-libhappah_la_CPPFLAGS = -I/usr/include/eigen3 -std=c++1z -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable
-libhappah_la_LDFLAGS = -version-info 0:0:0
+libhappah_la_CPPFLAGS = $(eigen3_CFLAGS) $(BOOST_CPPFLAGS)
+libhappah_la_CXXFLAGS = -std=c++1z -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable
+libhappah_la_LDFLAGS = -version-info 0:0:0 $(eigen3_LDFLAGS) $(BOOST_LDFLAGS)
+libhappah_la_LIBADD = -llpsolve55 $(eigen3_LIBS) $(BOOST_IOSTREAMS_LIB)
 


### PR DESCRIPTION
configure.ac:
- use AX_BOOST_BASE/AX_BOOST_IOSTREAMS to detect boost libraries; may
  require installation of appropriate m4 scripts (available through
  "autoconf-archive" on Debian- and Fedora-based systems)
- use pkg-config based checks where applicable
- use AC_CHECK_HEADER for glm and lpsolve55

lib/Makefile.am:
- adding preprocessor, compiler and linker flags as computed by autoconf
- specify computed library dependencies in libhappah_la_LIBADD, which
  instructs libtool to correctly record them as dependencies in
  libhappah.la (for linking against libhappah via libtool)